### PR TITLE
Add missing function definition cases

### DIFF
--- a/lib/annotations.js
+++ b/lib/annotations.js
@@ -9,7 +9,9 @@ var linetypes = {
   fnsig2  : { pattern: /^\s?exports\.(\w+)\s?=\s?function/, returns: { name:1 } },
   fnsig3  : { pattern: /^\s?module\.exports\s?=\s?function/, returns: { name:'anonymous' } },
   fnsig4  : { pattern: /exports\[['"](\w+)['"]\]\s*=\s*function/, returns: { name:1 } },
-  fnsig5  : { pattern: /^\s*var\s+(\w+)\s*=\s*function/, returns: { name:1 } }
+  fnsig5  : { pattern: /^\s*(var|let|const)\s+(\w+)\s*=\s*function/, returns: { name:2 } },
+  fnsig6  : { pattern: /^\s*(var|let|const)\s+(\w+)\s*=\s*new Function/, returns: { name:2 } },
+  fnsig7  : { pattern: /^\s*(var|let|const)\s+(\w+)\s*=\s*\(.*?\)\s*=>/, returns: { name:2 } }
 };
 
 function trim(str) {
@@ -82,6 +84,8 @@ function analyze(data) {
       case 'fnsig3':
       case 'fnsig4':
       case 'fnsig5':
+      case 'fnsig6':
+      case 'fnsig7':
         // Store current annotations under function name
         annotations[type.name] = current;
         current = {};

--- a/test/annotations.test.js
+++ b/test/annotations.test.js
@@ -10,6 +10,17 @@ function testfileTests(result, test) {
   test.deepEqual(result.testfunction3.duplicate, ['first','second','third']);
   test.equal(result.testfunction4.hi, 'there');
   test.equal(result.testfunction5.annotation, 'annotation for variable assigned function');
+  test.equal(result.testfunction6.annotation, 'test');
+  test.equal(result.testfunction7.annotation, 'test');
+  test.equal(result.testfunction8.annotation, 'test');
+  test.equal(result.testfunction9.annotation, 'test');
+  test.equal(result.testfunction10.annotation, 'test');
+  test.equal(result.testfunction11.annotation, 'test');
+  test.equal(result.testfunction12.annotation, 'test');
+  test.equal(result.testfunction13.annotation, 'test');
+  test.equal(result.testfunction14.annotation, 'test');
+  test.equal(result.testfunction15.annotation, 'test');
+  test.equal(result.testfunction16.annotation, 'test');
 }
 
 exports['Test 1: data/testfile.js, asynchronous'] = function(test) {

--- a/test/data/testfile.js
+++ b/test/data/testfile.js
@@ -54,3 +54,73 @@ exports['testfunction4'] = function() {
 var testfunction5 = function() {
   
 };
+
+/**
+ *
+ * @annotation test
+ */
+let testfunction6 = function() {
+
+};
+
+/**
+ *
+ * @annotation test
+ */
+const testfunction7 = function() {
+
+};
+
+/**
+ *
+ * @annotation test
+ */
+var testfunction8 = new Function();
+
+/**
+ *
+ * @annotation test
+ */
+let testfunction9 = new Function();
+
+/**
+ *
+ * @annotation test
+ */
+const testfunction10 = new Function();
+
+/**
+ *
+ * @annotation test
+ */
+var testfunction11 = () => console.log('Demo');
+
+/**
+ *
+ * @annotation test
+ */
+var testfunction12 = (name) => console.log('Hello, ' + name);
+
+/**
+ *
+ * @annotation test
+ */
+const testfunction13 = () => console.log('Demo');
+
+/**
+ *
+ * @annotation test
+ */
+const testfunction14 = (name) => console.log('Hello, ' + name);
+
+/**
+ *
+ * @annotation test
+ */
+let testfunction15 = () => console.log('Demo');
+
+/**
+ *
+ * @annotation test
+ */
+let testfunction16 = (name) => console.log('Hello, ' + name);


### PR DESCRIPTION
This PR implements additional support for `let` and `const` as well as arrow functions. Fixes #1.
